### PR TITLE
Implement maximum uses per visitor token

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
             language_version: python3.8
 
     # Flake8 includes pyflakes, pycodestyle, mccabe, pydocstyle, bandit
-    - repo: https://gitlab.com/pycqa/flake8
+    - repo: https://github.com/pycqa/flake8
       rev: 3.8.4
       hooks:
           - id: flake8

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# 👋
+
 # 🥼 YunoJuno Candidate Test (django-visitor-pass)
 
 Hi!


### PR DESCRIPTION
This will be a PR to enhance the `django-visitor-pass` library by allowing a maximum number of uses per visitor pass. It is a candidate test for SH.

I will add to this PR as I submit the test. For now, I'm adding a couple of commits so the CI/CD checks will work for this new account.